### PR TITLE
Fix sbcl compiler notes

### DIFF
--- a/src/designators.lisp
+++ b/src/designators.lisp
@@ -1,5 +1,10 @@
 (in-package :trivial-types)
 
+(deftype string-designator ()
+  '(or character
+       symbol
+       string))
+
 (defun character-designator-p (object)
   (and (typep object 'string-designator)
        (= 1 (length (string object)))))
@@ -36,8 +41,3 @@
 (deftype stream-designator ()
   '(or (member t nil)
        stream))
-
-(deftype string-designator ()
-  '(or character
-       symbol
-       string))

--- a/src/typespecs.lisp
+++ b/src/typespecs.lisp
@@ -11,6 +11,7 @@
         #+clisp (return (null
                          (nth-value 1 (ignore-errors
                                        (ext:type-expand type-specifier)))))
+        #-(or sbcl openmcl ecl clisp)
         (error "TYPE-SPECIFIER-P not available for this implementation"))))
 
 (deftype type-specifier () `(satisfies type-specifier-p))


### PR DESCRIPTION
Fix 2 sbcl compilation notes:

> ; in: DEFUN TYPE-SPECIFIER-P
> ;     (ERROR "TYPE-SPECIFIER-P not available for this implementation")
> ; note: **deleting unreachable code**

> ; in: DEFUN CHARACTER-DESIGNATOR-P
> ;     'TRIVIAL-TYPES:STRING-DESIGNATOR
> ; note: **can't open-code test of unknown type STRING-DESIGNATOR**